### PR TITLE
创建直播新增功能

### DIFF
--- a/src/LiveTrait.php
+++ b/src/LiveTrait.php
@@ -46,6 +46,30 @@ Trait LiveTrait
         if (isset($options['enable_comment'])) {
             $document['data']['attributes']['enable_comment'] = $options['enable_comment'];
         }
+        if (isset($options['vertical'])) {
+            $document['data']['attributes']['vertical'] = $options['vertical'];
+        }
+        if (isset($options['auto_transfer_class'])) {
+            $document['data']['attributes']['auto_transfer_class'] = $options['auto_transfer_class'];
+        }
+        if (isset($options['live_type'])) {
+            $document['data']['attributes']['live_type'] = $options['live_type'];
+        }
+        if (isset($options['password'])) {
+            $document['data']['attributes']['password'] = $options['password'];
+        }
+        if (!empty($options['course_category_id'])){
+            $document['data']['relationships']['course_category']['data']=[
+                'type' => 'category',
+                'id' => $options['course_category_id']
+            ];
+        }
+        if (!empty($options['class_category_id'])){
+            $document['data']['relationships']['class_category']['data']=[
+                'type' => 'category',
+                'id' => $options['class_category_id']
+            ];
+        }
         if (!empty($options['manager_ids'])) {
             foreach ($options['manager_ids'] as $manager_id) {
                 $document['data']['relationships']['managers']['data'][] = [


### PR DESCRIPTION
1.新增vertical 字段, 默认值0, 0表示横屏直播,1表示竖屏直播
2.新增live_type 字段, 默认值0, 0表示直播不对外可访问,1表示直播对外可访问
3.新增password字段,无默认值 ,允许直播对外可访问时，可以选择设置密码，4位数字类字符串，如"0000"
4.新增auto_transfer_class字段 ,默认值false, 是否开启直播回放,为true表示开启
5.新增course_category_id字段,无默认值,当auto_transfer_class为true时，需要制定直播的直播所属的课程素材分类
6.新增class_category_id字段,无默认值,当auto_transfer_class为true时，需要制定直播的直播所属的课程分类。